### PR TITLE
Check for recorder state before calling stop();

### DIFF
--- a/jspsych-6.3.1/extensions/jspsych-ext-webcam-recorder.js
+++ b/jspsych-6.3.1/extensions/jspsych-ext-webcam-recorder.js
@@ -62,7 +62,9 @@ jsPsych.extensions['webcam-recorder'] = (function () {
   
     extension.on_finish = function(params){
       if(state.recorder){
-        state.recorder.stop();
+          if(state.recorder.state == "recording"){
+            state.recorder.stop();
+          }
       }
       
       return {}


### PR DESCRIPTION
When recorder state is "inactive", calling stop() leads to Uncaught DOMException